### PR TITLE
Merging In things that CivEx uses and simple dupe fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.programmerdan.minecraft</groupId>
   <artifactId>SimpleAdminHacks</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.22</version>
+  <version>1.0.23</version>
   <name>SimpleAdminHacks</name>
   <url>https://github.com/DevotedMC/SimpleAdminHacks</url>
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -43,7 +43,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 		if (!this.potatoXPEnabled) plugin().log("  Potato XP Disabled");
 
 		this.villagerTrading = config.getBoolean("villagerTrading", false);
-		if(!villagerTrading) plugin().log("VillagerTrading is disabled");
+		if (!villagerTrading) plugin().log("VillagerTrading is disabled");
 
 		this.witherSpawning = config.getBoolean("witherSpawning", false);
 		if (!this.witherSpawning) plugin().log("Wither Spawning is disabled");
@@ -52,8 +52,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 		if (!this.enderChestPlacement) plugin().log("Placeing EnderChests is disabled");
 
 		this.weepingAngel = config.getBoolean("weepingAngel.enabled", false);
-		if(this.weepingAngel)
-		{
+		if (this.weepingAngel) {
 			this.weepingAngelEnv = config.getInt("weepingAngel.environment", 1);
 			this.weepingAngelPlayer = config.getInt("weepingAngel.playerKill", 5);
 
@@ -66,38 +65,32 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 	/**
 	 * @return If getting XP from potatos is enabled.
-     */
+	 */
 	public boolean isPotatoXPEnabled() {
 		return this.potatoXPEnabled;
 	}
 
-	public boolean isVillagerTrading()
-	{
+	public boolean isVillagerTrading() {
 		return this.villagerTrading;
 	}
 
-	public boolean isWitherSpawning()
-	{
+	public boolean isWitherSpawning() {
 		return this.witherSpawning;
 	}
 
-	public boolean isEnderChestPlacement()
-	{
+	public boolean isEnderChestPlacement() {
 		return this.enderChestPlacement;
 	}
 
-	public boolean isWeepingAngel()
-	{
+	public boolean isWeepingAngel() {
 		return this.weepingAngel;
 	}
 
-	public int getWeepingAngelEnv()
-	{
+	public int getWeepingAngelEnv() {
 		return this.weepingAngelEnv;
 	}
 
-	public int getWeepingAngelPlayer()
-	{
+	public int getWeepingAngelPlayer() {
 		return this.weepingAngelPlayer;
 	}
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -54,7 +54,7 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 		this.weepingAngel = config.getBoolean("weepingAngel.enabled", false);
 		if(this.weepingAngel)
 		{
-			this.weepingAngelEnv = config.getInt("weepingAngel.enviorment", 1);
+			this.weepingAngelEnv = config.getInt("weepingAngel.environment", 1);
 			this.weepingAngelPlayer = config.getInt("weepingAngel.playerKill", 5);
 
 			plugin().log("Weeping Angel is enabled. Times | Env[" + weepingAngelEnv + "] PK[" + weepingAngelPlayer + "]");

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFeaturesConfig.java
@@ -29,6 +29,10 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	private boolean witherSpawning;
 	private boolean enderChestPlacement;
 
+	private boolean weepingAngel;
+	private int weepingAngelEnv;
+	private int weepingAngelPlayer;
+
 	public GameFeaturesConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
 	}
@@ -46,6 +50,17 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 
 		this.enderChestPlacement = config.getBoolean("enderChestPlacement", false);
 		if (!this.enderChestPlacement) plugin().log("Placeing EnderChests is disabled");
+
+		this.weepingAngel = config.getBoolean("weepingAngel.enabled", false);
+		if(this.weepingAngel)
+		{
+			this.weepingAngelEnv = config.getInt("weepingAngel.enviorment", 1);
+			this.weepingAngelPlayer = config.getInt("weepingAngel.playerKill", 5);
+
+			plugin().log("Weeping Angel is enabled. Times | Env[" + weepingAngelEnv + "] PK[" + weepingAngelPlayer + "]");
+		}
+
+
 		/* Add additional feature config grabs here. */
 	}
 
@@ -70,5 +85,21 @@ public class GameFeaturesConfig extends SimpleHackConfig {
 	{
 		return this.enderChestPlacement;
 	}
+
+	public boolean isWeepingAngel()
+	{
+		return this.weepingAngel;
+	}
+
+	public int getWeepingAngelEnv()
+	{
+		return this.weepingAngelEnv;
+	}
+
+	public int getWeepingAngelPlayer()
+	{
+		return this.weepingAngelPlayer;
+	}
+
 }
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -12,6 +12,7 @@ public class GameFixesConfig extends SimpleHackConfig {
 	private boolean canStorageTeleport;
 	private boolean stopHopperDupe;
 	private boolean stopRailDupe;
+	private boolean stopEndPortalDeletion;
 	
 	public GameFixesConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
@@ -24,7 +25,10 @@ public class GameFixesConfig extends SimpleHackConfig {
 		stopHopperDupe = config.getBoolean("stopHopperDupe");
 
 		stopRailDupe = config.getBoolean("stopRailDupe", true);
-		if(stopRailDupe) plugin().log("Stop Rail Dupe is enabled");
+		if(stopRailDupe) plugin().log("Stop Rail Dupe is enabled.");
+
+		stopEndPortalDeletion = config.getBoolean("stopEndPortalDeletion", true);
+		if (stopEndPortalDeletion) plugin().log("Stop End Portal Deletion is enabled.");
 	}
 	
 	public boolean isBlockElytraBreakBug() {
@@ -46,5 +50,10 @@ public class GameFixesConfig extends SimpleHackConfig {
 	public boolean isStopRailDupe()
 	{
 		return stopRailDupe;
+	}
+
+	public boolean isStopEndPortalDeletion()
+	{
+		return stopEndPortalDeletion;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -11,6 +11,7 @@ public class GameFixesConfig extends SimpleHackConfig {
 	private double damageOnElytraBreakBug;
 	private boolean canStorageTeleport;
 	private boolean stopHopperDupe;
+	private boolean stopRailDupe;
 	
 	public GameFixesConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
@@ -21,6 +22,9 @@ public class GameFixesConfig extends SimpleHackConfig {
 		damageOnElytraBreakBug = config.getDouble("damageOnElytraBreakBug", 0.0d);
 		canStorageTeleport = config.getBoolean("canStorageTeleport");
 		stopHopperDupe = config.getBoolean("stopHopperDupe");
+
+		stopRailDupe = config.getBoolean("stopRailDupe", true);
+		if(stopRailDupe) plugin().log("Stop Rail Dupe is enabled");
 	}
 	
 	public boolean isBlockElytraBreakBug() {
@@ -37,5 +41,10 @@ public class GameFixesConfig extends SimpleHackConfig {
 	
 	public boolean isStopHopperDupe() {
 		return stopHopperDupe;
+	}
+
+	public boolean isStopRailDupe()
+	{
+		return stopRailDupe;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -33,14 +33,13 @@ public class GameFixesConfig extends SimpleHackConfig {
 		stopHopperDupe = config.getBoolean("stopHopperDupe");
 
 		stopRailDupe = config.getBoolean("stopRailDupe", true);
-		if(stopRailDupe) plugin().log("Stop Rail Dupe is enabled.");
+		if (stopRailDupe) plugin().log("Stop Rail Dupe is enabled.");
 
 		stopEndPortalDeletion = config.getBoolean("stopEndPortalDeletion", true);
 		if (stopEndPortalDeletion) plugin().log("Stop End Portal Deletion is enabled.");
 	}
 
-	private void wireUpArrays()
-	{
+	private void wireUpArrays() {
 		bfArray = new ArrayList<BlockFace>();
 		matArray = new ArrayList<Material>();
 
@@ -74,23 +73,19 @@ public class GameFixesConfig extends SimpleHackConfig {
 		return stopHopperDupe;
 	}
 
-	public boolean isStopRailDupe()
-	{
+	public boolean isStopRailDupe() {
 		return stopRailDupe;
 	}
 
-	public boolean isStopEndPortalDeletion()
-	{
+	public boolean isStopEndPortalDeletion() {
 		return stopEndPortalDeletion;
 	}
 
-	public ArrayList<BlockFace> getBfArray()
-	{
+	public ArrayList<BlockFace> getBfArray() {
 		return bfArray;
 	}
 
-	public ArrayList<Material> getMatArray()
-	{
+	public ArrayList<Material> getMatArray() {
 		return matArray;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -19,7 +19,8 @@ public class GameFixesConfig extends SimpleHackConfig {
 	private boolean stopEndPortalDeletion;
 
 	private ArrayList<BlockFace> bfArray;
-	private ArrayList<Material> matArray;
+	private ArrayList<Material> railArray;
+	private ArrayList<Material> pistonArray;
 
 	public GameFixesConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
@@ -41,13 +42,14 @@ public class GameFixesConfig extends SimpleHackConfig {
 
 	private void wireUpArrays() {
 		bfArray = new ArrayList<BlockFace>();
-		matArray = new ArrayList<Material>();
+		railArray = new ArrayList<Material>();
+		pistonArray = new ArrayList<Material>();
 
-		matArray.add(Material.RAILS);
-		matArray.add(Material.ACTIVATOR_RAIL);
-		matArray.add(Material.DETECTOR_RAIL);
-		matArray.add(Material.POWERED_RAIL);
-		matArray.add(Material.CARPET);
+		railArray.add(Material.RAILS);
+		railArray.add(Material.ACTIVATOR_RAIL);
+		railArray.add(Material.DETECTOR_RAIL);
+		railArray.add(Material.POWERED_RAIL);
+		railArray.add(Material.CARPET);
 
 		bfArray.add(BlockFace.NORTH);
 		bfArray.add(BlockFace.SOUTH);
@@ -55,6 +57,11 @@ public class GameFixesConfig extends SimpleHackConfig {
 		bfArray.add(BlockFace.WEST);
 		bfArray.add(BlockFace.UP);
 		bfArray.add(BlockFace.DOWN);
+
+		pistonArray.add(Material.PISTON_BASE);
+		pistonArray.add(Material.PISTON_EXTENSION);
+		pistonArray.add(Material.PISTON_MOVING_PIECE);
+		pistonArray.add(Material.PISTON_STICKY_BASE);
 	}
 
 	public boolean isBlockElytraBreakBug() {
@@ -85,7 +92,11 @@ public class GameFixesConfig extends SimpleHackConfig {
 		return bfArray;
 	}
 
-	public ArrayList<Material> getMatArray() {
-		return matArray;
+	public ArrayList<Material> getRailArray() {
+		return railArray;
+	}
+
+	public ArrayList<Material> getPistonArray() {
+		return pistonArray;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameFixesConfig.java
@@ -1,9 +1,13 @@
 package com.programmerdan.minecraft.simpleadminhacks.configs;
 
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHackConfig;
+
+import java.util.ArrayList;
 
 public class GameFixesConfig extends SimpleHackConfig {
 
@@ -13,11 +17,15 @@ public class GameFixesConfig extends SimpleHackConfig {
 	private boolean stopHopperDupe;
 	private boolean stopRailDupe;
 	private boolean stopEndPortalDeletion;
-	
+
+	private ArrayList<BlockFace> bfArray;
+	private ArrayList<Material> matArray;
+
 	public GameFixesConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
+		wireUpArrays();
 	}
-	
+
 	protected void wireup(ConfigurationSection config) {
 		blockElytraBreakBug = config.getBoolean("blockElytraBreakBug", true);
 		damageOnElytraBreakBug = config.getDouble("damageOnElytraBreakBug", 0.0d);
@@ -30,19 +38,38 @@ public class GameFixesConfig extends SimpleHackConfig {
 		stopEndPortalDeletion = config.getBoolean("stopEndPortalDeletion", true);
 		if (stopEndPortalDeletion) plugin().log("Stop End Portal Deletion is enabled.");
 	}
-	
+
+	private void wireUpArrays()
+	{
+		bfArray = new ArrayList<BlockFace>();
+		matArray = new ArrayList<Material>();
+
+		matArray.add(Material.RAILS);
+		matArray.add(Material.ACTIVATOR_RAIL);
+		matArray.add(Material.DETECTOR_RAIL);
+		matArray.add(Material.POWERED_RAIL);
+		matArray.add(Material.CARPET);
+
+		bfArray.add(BlockFace.NORTH);
+		bfArray.add(BlockFace.SOUTH);
+		bfArray.add(BlockFace.EAST);
+		bfArray.add(BlockFace.WEST);
+		bfArray.add(BlockFace.UP);
+		bfArray.add(BlockFace.DOWN);
+	}
+
 	public boolean isBlockElytraBreakBug() {
 		return blockElytraBreakBug;
 	}
-	
+
 	public double getDamageOnElytraBreakBug() {
 		return damageOnElytraBreakBug;
 	}
-	
+
 	public boolean canStorageTeleport() {
 		return canStorageTeleport;
 	}
-	
+
 	public boolean isStopHopperDupe() {
 		return stopHopperDupe;
 	}
@@ -55,5 +82,15 @@ public class GameFixesConfig extends SimpleHackConfig {
 	public boolean isStopEndPortalDeletion()
 	{
 		return stopEndPortalDeletion;
+	}
+
+	public ArrayList<BlockFace> getBfArray()
+	{
+		return bfArray;
+	}
+
+	public ArrayList<Material> getMatArray()
+	{
+		return matArray;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -35,8 +35,6 @@ public class GameTuningConfig extends SimpleHackConfig {
 	private boolean oneToOneNether;
 	private boolean returnNetherPortal;
 
-	private boolean chestedMinecartInventory;
-
 	public GameTuningConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
 	}
@@ -54,9 +52,6 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 		this.returnNetherPortal = config.getBoolean("returnNetherPortal", true);
 		if (!returnNetherPortal) plugin().log("Return Nether Portals disabled.");
-
-		this.chestedMinecartInventory = config.getBoolean("chestedMinecartInventory", false);
-		if (!chestedMinecartInventory) plugin().log("Chested Minecart Inventories are disabled.");
 
 		/* Add additional tuning config grabs here. */
 	}
@@ -196,11 +191,4 @@ public class GameTuningConfig extends SimpleHackConfig {
 		return returnNetherPortal;
 	}
 
-	/**
-	 * @return If return 
-	 */
-	public boolean isChestedMinecartInventory()
-	{
-		return chestedMinecartInventory;
-	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -35,6 +35,9 @@ public class GameTuningConfig extends SimpleHackConfig {
 	private boolean oneToOneNether;
 	private boolean returnNetherPortal;
 
+	private boolean chestedMinecartInventories;
+	private boolean hopperMinecartInventories;
+
 	public GameTuningConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
 	}
@@ -52,6 +55,12 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 		this.returnNetherPortal = config.getBoolean("returnNetherPortal", true);
 		if (!returnNetherPortal) plugin().log("Return Nether Portals disabled.");
+
+		this.chestedMinecartInventories = config.getBoolean("chestedMinecartInventories", true);
+		if (!chestedMinecartInventories) plugin().log("Chested Minecart Inventories are disabled.");
+
+		this.hopperMinecartInventories = config.getBoolean("hopperMinecartInventories", true);
+		if (!hopperMinecartInventories) plugin().log("Hopper Minecart Inventories are disabled.");
 
 		/* Add additional tuning config grabs here. */
 	}
@@ -189,6 +198,16 @@ public class GameTuningConfig extends SimpleHackConfig {
 	public boolean isReturnNetherPortal()
 	{
 		return returnNetherPortal;
+	}
+
+	public boolean isChestedMinecartInventories()
+	{
+		return chestedMinecartInventories;
+	}
+
+	public boolean isHopperMinecartInventories()
+	{
+		return hopperMinecartInventories;
 	}
 
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -67,10 +67,9 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 	/**
 	 * Wireup for Chunk Limits configuration
-	 * 
-	 * @author ProgrammerDan
 	 *
-	 */ 
+	 * @author ProgrammerDan
+	 */
 	private void wireupChunkLimits(ConfigurationSection config) {
 		this.blockEntityLimits = new HashMap<Material, Integer>();
 		this.exemptFromLimits = new HashSet<UUID>();
@@ -79,7 +78,7 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 		this.chunkLimitsEnabled = config.getBoolean("enabled", false);
 		this.chunkLimitsExceededMessage = ChatColor.translateAlternateColorCodes('&',
-				config.getString("exceededMessage", 
+				config.getString("exceededMessage",
 						ChatColor.RED + "Limit for this chunk reached, you cannot place that! Use a different block."));
 
 		// for each "chunkLimits.tileEntities: " entry, record limit.
@@ -92,7 +91,7 @@ public class GameTuningConfig extends SimpleHackConfig {
 			this.blockEntityLimits.put(toBlock, limit);
 			plugin().log(Level.INFO, " Limiting {0} to {1} per chunk", toBlock.toString(), limit);
 		}
-		
+
 		// for each "chunkLimits.exempt: " entry, record limit.
 		List<String> exempts = config.getStringList("exempt");
 		for (String exempt : exempts) {
@@ -179,7 +178,7 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 	/**
 	 * @return If setting your spawn with a bed during the daytime is enabled.
- 	*/
+	 */
 	public boolean areDaytimeBedsEnabled() {
 		return daytimeBedEnabled;
 	}
@@ -187,26 +186,22 @@ public class GameTuningConfig extends SimpleHackConfig {
 	/**
 	 * @return If one to one nether is enabled.
 	 */
-	public boolean isOneToOneNether()
-	{
+	public boolean isOneToOneNether() {
 		return oneToOneNether;
 	}
 
 	/**
 	 * @return If return portals are enabled.
 	 */
-	public boolean isReturnNetherPortal()
-	{
+	public boolean isReturnNetherPortal() {
 		return returnNetherPortal;
 	}
 
-	public boolean isChestedMinecartInventories()
-	{
+	public boolean isChestedMinecartInventories() {
 		return chestedMinecartInventories;
 	}
 
-	public boolean isHopperMinecartInventories()
-	{
+	public boolean isHopperMinecartInventories() {
 		return hopperMinecartInventories;
 	}
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -32,6 +32,9 @@ public class GameTuningConfig extends SimpleHackConfig {
 	private boolean daytimeBedEnabled;
 	private String daytimeBedSpawnSetMessage;
 
+	private boolean oneToOneNether;
+	private boolean returnNetherPortal;
+
 	public GameTuningConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
 	}
@@ -43,6 +46,12 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 		ConfigurationSection daytimeBed = config.getConfigurationSection("daytimeBed");
 		wireupDaytimeBed(daytimeBed);
+
+		this.oneToOneNether = config.getBoolean("oneToOneNether", false);
+		if (oneToOneNether) plugin().log("One to One Nether is enabled.");
+
+		this.returnNetherPortal = config.getBoolean("returnNetherPortal", true);
+		if (!returnNetherPortal) plugin().log("Return Nether Portals disabled.");
 
 		/* Add additional tuning config grabs here. */
 	}
@@ -103,7 +112,7 @@ public class GameTuningConfig extends SimpleHackConfig {
 	 * Wireup for enabling setting your spawn during the day.
 	 *
 	 * @author Amelorate
-     */
+	 */
 	private void wireupDaytimeBed(ConfigurationSection config) {
 		if (config == null) {
 			this.daytimeBedEnabled = false;
@@ -154,15 +163,31 @@ public class GameTuningConfig extends SimpleHackConfig {
 	/**
 	 * @return The message that is sent to the player if they right click on a bed and set their spawn.
 	 * Empty string if there should not be a message, and null if daytime beds are disabled.
-     */
+	 */
 	public String getDaytimeBedSpawnSetMessage() {
 		return daytimeBedEnabled ? daytimeBedSpawnSetMessage : null;
 	}
 
 	/**
 	 * @return If setting your spawn with a bed during the daytime is enabled.
-     */
+ 	*/
 	public boolean areDaytimeBedsEnabled() {
 		return daytimeBedEnabled;
+	}
+
+	/**
+	 * @return If one to one nether is enabled.
+	 */
+	public boolean isOneToOneNether()
+	{
+		return oneToOneNether;
+	}
+
+	/**
+	 * @return If return portals are enabled.
+	 */
+	public boolean isReturnNetherPortal()
+	{
+		return returnNetherPortal;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/configs/GameTuningConfig.java
@@ -35,6 +35,8 @@ public class GameTuningConfig extends SimpleHackConfig {
 	private boolean oneToOneNether;
 	private boolean returnNetherPortal;
 
+	private boolean chestedMinecartInventory;
+
 	public GameTuningConfig(SimpleAdminHacks plugin, ConfigurationSection base) {
 		super(plugin, base);
 	}
@@ -52,6 +54,9 @@ public class GameTuningConfig extends SimpleHackConfig {
 
 		this.returnNetherPortal = config.getBoolean("returnNetherPortal", true);
 		if (!returnNetherPortal) plugin().log("Return Nether Portals disabled.");
+
+		this.chestedMinecartInventory = config.getBoolean("chestedMinecartInventory", false);
+		if (!chestedMinecartInventory) plugin().log("Chested Minecart Inventories are disabled.");
 
 		/* Add additional tuning config grabs here. */
 	}
@@ -189,5 +194,13 @@ public class GameTuningConfig extends SimpleHackConfig {
 	public boolean isReturnNetherPortal()
 	{
 		return returnNetherPortal;
+	}
+
+	/**
+	 * @return If return 
+	 */
+	public boolean isChestedMinecartInventory()
+	{
+		return chestedMinecartInventory;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -32,13 +32,13 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 /**
  * This is a grab-bag class to hold any _features_ related configurations that impact the
  * game, server-wide. Mostly focused on turning things on or off.
- * <p/>
+ *
  * It's part of a series of focused hacks.
- * <p/>
+ *
  * {@link GameFixes} is focused on things that are broken or don't work, and attempts to fix them.
  * {@link GameFeatures} focuses on enabling and disabling features, like elytra, various potion states.
  * {@link GameTuning} neither fixes nor disables, but rather adjusts and reconfigures.
- * <p/>
+ *
  * Currently you can control the following:
  * - Disable Potato XP
  */

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -112,6 +112,13 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 				genStatus.append("disabled\n");
 			}
 
+			genStatus.append(" WeepAngel is ");
+			if(config.isWeepingAngel()){
+				genStatus.append("enabled\n");
+			} else {
+				genStatus.append("disabled\n");
+			}
+
 			// more?
 		} else {
 			genStatus.append("inactive");

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFeatures.java
@@ -32,15 +32,15 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 /**
  * This is a grab-bag class to hold any _features_ related configurations that impact the
  * game, server-wide. Mostly focused on turning things on or off.
- *
+ * <p/>
  * It's part of a series of focused hacks.
- *
+ * <p/>
  * {@link GameFixes} is focused on things that are broken or don't work, and attempts to fix them.
  * {@link GameFeatures} focuses on enabling and disabling features, like elytra, various potion states.
  * {@link GameTuning} neither fixes nor disables, but rather adjusts and reconfigures.
- *
+ * <p/>
  * Currently you can control the following:
- *  - Disable Potato XP
+ * - Disable Potato XP
  */
 public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements Listener {
 	public static final String NAME = "GameFeatures";
@@ -92,28 +92,28 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 			}
 
 			genStatus.append(" Villager Trading is ");
-			if (config.isVillagerTrading()){
+			if (config.isVillagerTrading()) {
 				genStatus.append("enabled\n");
 			} else {
 				genStatus.append("disabled\n");
 			}
 
 			genStatus.append(" Wither Spawning is ");
-			if (config.isWitherSpawning()){
+			if (config.isWitherSpawning()) {
 				genStatus.append("enabled\n");
 			} else {
 				genStatus.append("disabled\n");
 			}
 
 			genStatus.append(" Ender Chest placement is ");
-			if(config.isEnderChestPlacement()){
+			if (config.isEnderChestPlacement()) {
 				genStatus.append("enabled\n");
 			} else {
 				genStatus.append("disabled\n");
 			}
 
 			genStatus.append(" WeepAngel is ");
-			if(config.isWeepingAngel()){
+			if (config.isWeepingAngel()) {
 				genStatus.append("enabled\n");
 			} else {
 				genStatus.append("disabled\n");
@@ -135,7 +135,7 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 	/**
 	 * Perhaps eventually generalize?
 	 */
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void potatoXP(FurnaceExtractEvent event) {
 		if (!config.isEnabled() || config.isPotatoXPEnabled()) return;
 		try {
@@ -151,16 +151,12 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 	}
 
 	@EventHandler(priority = EventPriority.LOW)
-	public void disableVillagerTrading(PlayerInteractEntityEvent event)
-	{
-		if (!config.isVillagerTrading())
-		{
+	public void disableVillagerTrading(PlayerInteractEntityEvent event) {
+		if (!config.isVillagerTrading()) {
 			Entity npc = event.getRightClicked();
 
-			if (npc != null)
-			{
-				if (npc.getType().equals(EntityType.VILLAGER))
-				{
+			if (npc != null) {
+				if (npc.getType().equals(EntityType.VILLAGER)) {
 					event.setCancelled(true);
 				}
 			}
@@ -168,78 +164,57 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 	}
 
 	@EventHandler(priority = EventPriority.LOW)
-	public void disableWitherSpawning(CreatureSpawnEvent event)
-	{
-		if (!config.isWitherSpawning())
-		{
-			if (event.getEntityType().equals(EntityType.WITHER))
-			{
-			   event.setCancelled(true);
+	public void disableWitherSpawning(CreatureSpawnEvent event) {
+		if (!config.isWitherSpawning()) {
+			if (event.getEntityType().equals(EntityType.WITHER)) {
+				event.setCancelled(true);
 			}
 		}
 	}
 
 	@EventHandler(priority = EventPriority.LOW)
-	public void disableEnderChestPlacement(BlockPlaceEvent event)
-	{
-		if (!config.isEnderChestPlacement())
-		{
-			if (event.getBlock().getType().equals(Material.ENDER_CHEST))
-			{
+	public void disableEnderChestPlacement(BlockPlaceEvent event) {
+		if (!config.isEnderChestPlacement()) {
+			if (event.getBlock().getType().equals(Material.ENDER_CHEST)) {
 				event.setCancelled(true);
 			}
 		}
 	}
 
 	@EventHandler(priority = EventPriority.HIGH)
-	public void weepingAngelListener(PlayerDeathEvent event)
-	{
-		if(!config.isWeepingAngel())
-		{
+	public void weepingAngelListener(PlayerDeathEvent event) {
+		if (!config.isWeepingAngel()) {
 			return;
 		}
 
-		if(event.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent)
-		{
+		if (event.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent) {
 			EntityDamageByEntityEvent evt = ((EntityDamageByEntityEvent) event.getEntity().getLastDamageCause());
 			LivingEntity killer = null;
 
-			if (evt.getDamager() instanceof LivingEntity)
-			{
+			if (evt.getDamager() instanceof LivingEntity) {
 				killer = (LivingEntity) evt.getDamager();
-			}
-			else if (evt.getDamager() instanceof Projectile)
-			{
+			} else if (evt.getDamager() instanceof Projectile) {
 				Projectile projectile = (Projectile) evt.getDamager();
 
-				if (projectile.getShooter() instanceof LivingEntity)
-				{
+				if (projectile.getShooter() instanceof LivingEntity) {
 					killer = (LivingEntity) projectile.getShooter();
 				}
 			}
 
-			if (killer != null)
-			{
-				if (killer instanceof Player)
-				{
+			if (killer != null) {
+				if (killer instanceof Player) {
 					banPlayer(event.getEntity().getPlayer(), config.getWeepingAngelPlayer());
-				}
-				else
-				{
+				} else {
 					banPlayer(event.getEntity().getPlayer(), config.getWeepingAngelEnv());
 				}
 			}
-		}
-		else
-		{
+		} else {
 			banPlayer(event.getEntity().getPlayer(), config.getWeepingAngelEnv());
 		}
 	}
 
-	private void banPlayer(Player p, int minutes)
-	{
-		if(!config.isWeepingAngel())
-		{
+	private void banPlayer(Player p, int minutes) {
+		if (!config.isWeepingAngel()) {
 			return;
 		}
 
@@ -247,10 +222,8 @@ public class GameFeatures extends SimpleHack<GameFeaturesConfig> implements List
 		Bukkit.getServer().getBanList(BanList.Type.NAME).addBan(p.getName(), "You've been banned for " + minutes +
 				" minutes due to your death.", exp, "weepingAngel");
 
-		Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(SimpleAdminHacks.instance(), new Runnable()
-		{
-			public void run()
-			{
+		Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(SimpleAdminHacks.instance(), new Runnable() {
+			public void run() {
 				p.kickPlayer("You've been banned for " + minutes + " minutes due to your death.");
 			}
 		}, 2L);

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -3,12 +3,15 @@ package com.programmerdan.minecraft.simpleadminhacks.hacks;
 import org.bukkit.Material;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
@@ -137,7 +140,66 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		}
 		
 	}
-	
+
+	//This is to stop rail dupe glitch via pistons
+	private static final BlockFace[] faces_ = new BlockFace[]
+	{
+		BlockFace.NORTH,
+		BlockFace.SOUTH,
+		BlockFace.EAST,
+		BlockFace.WEST,
+		BlockFace.UP,
+		BlockFace.DOWN
+	};
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPistonPushRail(BlockPistonExtendEvent event)
+	{
+		if(config.isStopRailDupe())
+		{
+			for (Block block : event.getBlocks())
+			{
+				Material type = block.getType();
+				if(type == Material.RAILS ||
+					type == Material.ACTIVATOR_RAIL ||
+					type == Material.DETECTOR_RAIL ||
+					type == Material.POWERED_RAIL)
+				{
+					event.setCancelled(true);
+				}
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onRailPlace(BlockPlaceEvent event)
+	{
+		if(config.isStopRailDupe())
+		{
+			Block block = event.getBlock();
+			Material type = block.getType();
+
+			if(type == Material.RAILS ||
+				type == Material.ACTIVATOR_RAIL ||
+				type == Material.DETECTOR_RAIL ||
+				type == Material.POWERED_RAIL)
+			{
+				for (BlockFace face : faces_)
+				{
+					type = block.getRelative(face).getType();
+
+					if(type == Material.PISTON_BASE ||
+						type == Material.PISTON_EXTENSION ||
+						type == Material.PISTON_MOVING_PIECE ||
+						type == Material.PISTON_STICKY_BASE)
+					{
+						event.setCancelled(true);
+					}
+				}
+			}
+		}
+	}
+
 	public static GameFixesConfig generate(SimpleAdminHacks plugin, ConfigurationSection config) {
 		return new GameFixesConfig(plugin, config);
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -31,7 +31,7 @@ import java.util.HashSet;
 
 public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	public static final String NAME = "GameFixes";
-	
+
 	public GameFixes(SimpleAdminHacks plugin, GameFixesConfig config) {
 		super(plugin, config);
 	}
@@ -100,21 +100,21 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		}
 		return genStatus.toString();
 	}
-	
+
 	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		if (!config.isEnabled() || !config.isBlockElytraBreakBug()) return;
 		Block block = event.getBlock();
 		Player player = event.getPlayer();
 		if (block == null || player == null) return;
-		
+
 		if(!player.getLocation().equals(block.getLocation())
 				&& player.getEyeLocation().getBlock().getType() != Material.AIR) {
 			event.setCancelled(true);
 			player.damage(config.getDamageOnElytraBreakBug());
 		}
 	}
-	
+
 	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
 	public void onEntityTeleport(EntityTeleportEvent event) {
 		if (!config.isEnabled() || config.canStorageTeleport()) return;
@@ -130,7 +130,7 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			event.setCancelled(true);
 		}
 	}
-	
+
 	@EventHandler
 	public void onInventoryMoveItem(InventoryMoveItemEvent event) {
 		if (!config.isEnabled() || !config.isStopHopperDupe()) return;
@@ -143,28 +143,8 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			//They're pointing into each other and will eventually dupe
 			event.setCancelled(true);
 		}
-		
+
 	}
-
-	//This is to stop rail dupe glitch via pistons
-	private static final BlockFace[] faces_ = new BlockFace[]
-	{
-		BlockFace.NORTH,
-		BlockFace.SOUTH,
-		BlockFace.EAST,
-		BlockFace.WEST,
-		BlockFace.UP,
-		BlockFace.DOWN
-	};
-
-	private static final Material[] stopDupes_ = new Material[]
-	{
-		Material.RAILS,
-		Material.ACTIVATOR_RAIL,
-		Material.DETECTOR_RAIL,
-		Material.POWERED_RAIL,
-		Material.CARPET
-	};
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPistonPushRail(BlockPistonExtendEvent event)
@@ -174,13 +154,11 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			for (Block block : event.getBlocks())
 			{
 				Material type = block.getType();
-				for (Material mat : stopDupes_)
+
+				if (config.getMatArray().contains(type))
 				{
-					if (type == mat)
-					{
-						event.setCancelled(true);
-						return;
-					}
+					event.setCancelled(true);
+					return;
 				}
 			}
 		}
@@ -194,22 +172,16 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			Block block = event.getBlock();
 			Material type = block.getType();
 
-			for (Material mat : stopDupes_)
+			if (config.getMatArray().contains(type))
 			{
-				if (type == mat)
+				for (BlockFace face : config.getBfArray())
 				{
-					for (BlockFace face : faces_)
-					{
-						type = block.getRelative(face).getType();
+					type = block.getRelative(face).getType();
 
-						if(type == Material.PISTON_BASE ||
-								type == Material.PISTON_EXTENSION ||
-								type == Material.PISTON_MOVING_PIECE ||
-								type == Material.PISTON_STICKY_BASE)
-						{
-							event.setCancelled(true);
-							return;
-						}
+					if (config.getMatArray().contains(type))
+					{
+						event.setCancelled(true);
+						return;
 					}
 				}
 			}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -9,6 +9,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -108,6 +109,14 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	
 	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
 	public void onEntityTeleport(EntityTeleportEvent event) {
+		if (!config.isEnabled() || config.canStorageTeleport()) return;
+		if (event.getEntity() instanceof InventoryHolder) {
+			event.setCancelled(true);
+		}
+	}
+
+	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
+	public void onEntityPortal(EntityPortalEvent event) {
 		if (!config.isEnabled() || config.canStorageTeleport()) return;
 		if (event.getEntity() instanceof InventoryHolder) {
 			event.setCancelled(true);

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -26,9 +26,6 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameFixesConfig;
 
-import java.util.HashMap;
-import java.util.HashSet;
-
 public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	public static final String NAME = "GameFixes";
 
@@ -152,7 +149,7 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			for (Block block : event.getBlocks()) {
 				Material type = block.getType();
 
-				if (config.getMatArray().contains(type)) {
+				if (config.getRailArray().contains(type)) {
 					event.setCancelled(true);
 					return;
 				}
@@ -166,11 +163,11 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			Block block = event.getBlock();
 			Material type = block.getType();
 
-			if (config.getMatArray().contains(type)) {
+			if (config.getRailArray().contains(type)) {
 				for (BlockFace face : config.getBfArray()) {
 					type = block.getRelative(face).getType();
 
-					if (config.getMatArray().contains(type)) {
+					if (config.getPistonArray().contains(type)) {
 						event.setCancelled(true);
 						return;
 					}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -26,6 +26,9 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameFixesConfig;
 
+import java.util.HashMap;
+import java.util.HashSet;
+
 public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	public static final String NAME = "GameFixes";
 	
@@ -154,6 +157,15 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		BlockFace.DOWN
 	};
 
+	private static final Material[] stopDupes_ = new Material[]
+	{
+		Material.RAILS,
+		Material.ACTIVATOR_RAIL,
+		Material.DETECTOR_RAIL,
+		Material.POWERED_RAIL,
+		Material.CARPET
+	};
+
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void onPistonPushRail(BlockPistonExtendEvent event)
 	{
@@ -162,12 +174,13 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			for (Block block : event.getBlocks())
 			{
 				Material type = block.getType();
-				if(type == Material.RAILS ||
-					type == Material.ACTIVATOR_RAIL ||
-					type == Material.DETECTOR_RAIL ||
-					type == Material.POWERED_RAIL)
+				for (Material mat : stopDupes_)
 				{
-					event.setCancelled(true);
+					if (type == mat)
+					{
+						event.setCancelled(true);
+						return;
+					}
 				}
 			}
 		}
@@ -181,21 +194,22 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 			Block block = event.getBlock();
 			Material type = block.getType();
 
-			if(type == Material.RAILS ||
-				type == Material.ACTIVATOR_RAIL ||
-				type == Material.DETECTOR_RAIL ||
-				type == Material.POWERED_RAIL)
+			for (Material mat : stopDupes_)
 			{
-				for (BlockFace face : faces_)
+				if (type == mat)
 				{
-					type = block.getRelative(face).getType();
-
-					if(type == Material.PISTON_BASE ||
-						type == Material.PISTON_EXTENSION ||
-						type == Material.PISTON_MOVING_PIECE ||
-						type == Material.PISTON_STICKY_BASE)
+					for (BlockFace face : faces_)
 					{
-						event.setCancelled(true);
+						type = block.getRelative(face).getType();
+
+						if(type == Material.PISTON_BASE ||
+								type == Material.PISTON_EXTENSION ||
+								type == Material.PISTON_MOVING_PIECE ||
+								type == Material.PISTON_STICKY_BASE)
+						{
+							event.setCancelled(true);
+							return;
+						}
 					}
 				}
 			}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -38,7 +38,7 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 
 	@Override
 	public void registerListeners() {
-		if(config != null && config.isEnabled()) {
+		if (config != null && config.isEnabled()) {
 			plugin().log("Registering GameFixes listeners");
 			plugin().registerListener(this);
 		}
@@ -71,29 +71,29 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	public String status() {
 		StringBuilder genStatus = new StringBuilder();
 		genStatus.append("GameFixes is ");
-		if(config != null && config.isEnabled()) {
+		if (config != null && config.isEnabled()) {
 			genStatus.append(ChatColor.GREEN).append("active\n").append(ChatColor.RESET);
-			if(config.isBlockElytraBreakBug()) {
+			if (config.isBlockElytraBreakBug()) {
 				genStatus.append("   Block elytra break bug is ").append(ChatColor.GREEN).append("enabled\n")
-					.append(ChatColor.RESET);
+						.append(ChatColor.RESET);
 				genStatus.append("   Will deal " + config.getDamageOnElytraBreakBug() + " damage to players\n");
 			} else {
 				genStatus.append("   Block elytra break bug is ").append(ChatColor.RED).append("disabled\n")
-					.append(ChatColor.RESET);
+						.append(ChatColor.RESET);
 			}
-			if(!config.canStorageTeleport()) {
+			if (!config.canStorageTeleport()) {
 				genStatus.append("   Block storage entities from teleporting to prevents exploits ")
-					.append(ChatColor.GREEN).append("enabled\n").append(ChatColor.RESET);
+						.append(ChatColor.GREEN).append("enabled\n").append(ChatColor.RESET);
 			} else {
 				genStatus.append("   Block storage entities from teleporting to prevents exploits ")
-					.append(ChatColor.RED).append("disabled\n").append(ChatColor.RESET);
+						.append(ChatColor.RED).append("disabled\n").append(ChatColor.RESET);
 			}
-			if(config.isStopHopperDupe()) {
+			if (config.isStopHopperDupe()) {
 				genStatus.append("   Hopper self-feed duplication exploit fix ")
-					.append(ChatColor.GREEN).append("enabled\n").append(ChatColor.RESET);
+						.append(ChatColor.GREEN).append("enabled\n").append(ChatColor.RESET);
 			} else {
 				genStatus.append("   Hopper self-feed duplication exploit fix ")
-					.append(ChatColor.RED).append("disabled\n").append(ChatColor.RESET);
+						.append(ChatColor.RED).append("disabled\n").append(ChatColor.RESET);
 			}
 		} else {
 			genStatus.append(ChatColor.RED).append("inactive").append(ChatColor.RESET);
@@ -101,21 +101,21 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		return genStatus.toString();
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		if (!config.isEnabled() || !config.isBlockElytraBreakBug()) return;
 		Block block = event.getBlock();
 		Player player = event.getPlayer();
 		if (block == null || player == null) return;
 
-		if(!player.getLocation().equals(block.getLocation())
+		if (!player.getLocation().equals(block.getLocation())
 				&& player.getEyeLocation().getBlock().getType() != Material.AIR) {
 			event.setCancelled(true);
 			player.damage(config.getDamageOnElytraBreakBug());
 		}
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onEntityTeleport(EntityTeleportEvent event) {
 		if (!config.isEnabled() || config.canStorageTeleport()) return;
 		if (event.getEntity() instanceof InventoryHolder) {
@@ -123,7 +123,7 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 		}
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onEntityPortal(EntityPortalEvent event) {
 		if (!config.isEnabled() || config.canStorageTeleport()) return;
 		if (event.getEntity() instanceof InventoryHolder) {
@@ -134,12 +134,12 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	@EventHandler
 	public void onInventoryMoveItem(InventoryMoveItemEvent event) {
 		if (!config.isEnabled() || !config.isStopHopperDupe()) return;
-		if((event.getDestination() == null) || (event.getSource() == null) ||
+		if ((event.getDestination() == null) || (event.getSource() == null) ||
 				!(InventoryType.HOPPER.equals(event.getDestination().getType())) ||
 				!(InventoryType.HOPPER.equals(event.getSource().getType()))) return;
 		Hopper source = (Hopper) event.getSource().getLocation().getBlock().getState().getData();
 		Hopper dest = (Hopper) event.getDestination().getLocation().getBlock().getState().getData();
-		if(source.getFacing().getOppositeFace() == dest.getFacing()) {
+		if (source.getFacing().getOppositeFace() == dest.getFacing()) {
 			//They're pointing into each other and will eventually dupe
 			event.setCancelled(true);
 		}
@@ -147,16 +147,12 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPistonPushRail(BlockPistonExtendEvent event)
-	{
-		if(config.isStopRailDupe())
-		{
-			for (Block block : event.getBlocks())
-			{
+	public void onPistonPushRail(BlockPistonExtendEvent event) {
+		if (config.isStopRailDupe()) {
+			for (Block block : event.getBlocks()) {
 				Material type = block.getType();
 
-				if (config.getMatArray().contains(type))
-				{
+				if (config.getMatArray().contains(type)) {
 					event.setCancelled(true);
 					return;
 				}
@@ -165,21 +161,16 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onRailPlace(BlockPlaceEvent event)
-	{
-		if(config.isStopRailDupe())
-		{
+	public void onRailPlace(BlockPlaceEvent event) {
+		if (config.isStopRailDupe()) {
 			Block block = event.getBlock();
 			Material type = block.getType();
 
-			if (config.getMatArray().contains(type))
-			{
-				for (BlockFace face : config.getBfArray())
-				{
+			if (config.getMatArray().contains(type)) {
+				for (BlockFace face : config.getBfArray()) {
 					type = block.getRelative(face).getType();
 
-					if (config.getMatArray().contains(type))
-					{
+					if (config.getMatArray().contains(type)) {
 						event.setCancelled(true);
 						return;
 					}
@@ -190,31 +181,24 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 
 	//Trying to stop players from deleting end portals
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event)
-	{
-		if(config.isStopEndPortalDeletion())
-		{
+	public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event) {
+		if (config.isStopEndPortalDeletion()) {
 			Block block = event.getBlockClicked().getRelative(event.getBlockFace());
 
-			if(block.getType() == Material.ENDER_PORTAL)
-			{
+			if (block.getType() == Material.ENDER_PORTAL) {
 				event.setCancelled(true);
 			}
 		}
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onDispenseEvent(BlockDispenseEvent event)
-	{
-		if(config.isStopEndPortalDeletion())
-		{
-			if(event.getBlock().getType() == Material.DISPENSER)
-			{
-				Dispenser disp = (Dispenser)event.getBlock().getState().getData();
+	public void onDispenseEvent(BlockDispenseEvent event) {
+		if (config.isStopEndPortalDeletion()) {
+			if (event.getBlock().getType() == Material.DISPENSER) {
+				Dispenser disp = (Dispenser) event.getBlock().getState().getData();
 				Material type = event.getBlock().getRelative(disp.getFacing()).getType();
 
-				if(type == Material.ENDER_PORTAL)
-				{
+				if (type == Material.ENDER_PORTAL) {
 					event.setCancelled(true);
 				}
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameFixes.java
@@ -10,14 +10,16 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.material.Dispenser;
 import org.bukkit.material.Hopper;
 
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
@@ -196,6 +198,40 @@ public class GameFixes extends SimpleHack<GameFixesConfig> implements Listener {
 						event.setCancelled(true);
 					}
 				}
+			}
+		}
+	}
+
+	//Trying to stop players from deleting end portals
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event)
+	{
+		if(config.isStopEndPortalDeletion())
+		{
+			Block block = event.getBlockClicked().getRelative(event.getBlockFace());
+
+			if(block.getType() == Material.ENDER_PORTAL)
+			{
+				event.setCancelled(true);
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onDispenseEvent(BlockDispenseEvent event)
+	{
+		if(config.isStopEndPortalDeletion())
+		{
+			if(event.getBlock().getType() == Material.DISPENSER)
+			{
+				Dispenser disp = (Dispenser)event.getBlock().getState().getData();
+				Material type = event.getBlock().getRelative(disp.getFacing()).getType();
+
+				if(type == Material.ENDER_PORTAL)
+				{
+					event.setCancelled(true);
+				}
+
 			}
 		}
 	}

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -42,18 +42,18 @@ import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.InventoryHolder;
 
 /**
- * This is a grab-bag class to hold any _tuning_ related configurations that impact the 
+ * This is a grab-bag class to hold any _tuning_ related configurations that impact the
  * game, server-wide.
- * 
+ * <p/>
  * It's part of a series of focused hacks.
- *
+ * <p/>
  * {@link GameFixes} is focused on things that are broken or don't work, and attempts to fix them.
  * {@link GameFeatures} focuses on enabling and disabling features, like elytra, various potion states.
  * {@link GameTuning} neither fixes nor disables, but rather adjusts and reconfigures.
- *
+ * <p/>
  * Currently you can control the following:
- *  - BlockEntity limits per chunk
- *  - Setting bed during the day instead of just at night
+ * - BlockEntity limits per chunk
+ * - Setting bed during the day instead of just at night
  */
 public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener {
 	public static final String NAME = "GameTuning";
@@ -112,9 +112,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			genStatus.append("  One To One Nether is ");
 			if (config.isOneToOneNether()) {
 				genStatus.append("enabled\n");
-			}
-			else
-			{
+			} else {
 				genStatus.append("disabled\n");
 			}
 
@@ -133,13 +131,13 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 
 	/**
 	 * Many thanks to BlackXNT for his work on this event in Humbug, which I have largely copied and expanded.
-	 *
+	 * <p/>
 	 * This tracks block placements, and if a limit is configured and the block is a TileEntity w/ state,
 	 * will reject the placement if otherwise it would exceed limits for the Chunk.
-	 * 
+	 *
 	 * @param event the Placement event.
 	 */
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void chunkLimits(BlockPlaceEvent event) {
 		if (!config.isEnabled() || !config.areChunkLimitsEnabled()) return;
 		try {
@@ -160,22 +158,22 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			if (block.getChunk().getTileEntities() == null) return;
 
 			int current = 0;
-			for (BlockState state : block.getChunk().getTileEntities() ) {
+			for (BlockState state : block.getChunk().getTileEntities()) {
 				if (state != null && mat.equals(state.getType())) {
-					if ( ++current > limit) {
+					if (++current > limit) {
 						event.setCancelled(true);
-						player.sendMessage( config.getChunkLimitsExceededMessage() );
+						player.sendMessage(config.getChunkLimitsExceededMessage());
 						return;
 					}
 				}
 			}
 		} catch (Exception e) {
-			plugin().log(Level.WARNING, "Failed to measure chunk limit", e);	
+			plugin().log(Level.WARNING, "Failed to measure chunk limit", e);
 		}
 	}
 
 	// If any limit at all, cancel the piston event.
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled=true) 
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void chunkLimitsExploitExtend(BlockPistonExtendEvent event) {
 		if (!config.isEnabled() || !config.areChunkLimitsEnabled()) return;
 		List<Block> blocks = event.getBlocks();
@@ -190,7 +188,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 	}
 
 	// Yes, this is identical ...
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void chunkLimitsExploitRetract(BlockPistonRetractEvent event) {
 		if (!config.isEnabled() || !config.areChunkLimitsEnabled()) return;
 		List<Block> blocks = event.getBlocks();
@@ -226,10 +224,8 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPortalTravel(EntityPortalEvent event)
-	{
-		if (config.isOneToOneNether())
-		{
+	public void onPortalTravel(EntityPortalEvent event) {
+		if (config.isOneToOneNether()) {
 			Location newLoc = event.getFrom();
 			newLoc.setWorld(event.getTo().getWorld());
 			event.setTo(newLoc);
@@ -237,23 +233,18 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onPlayerPortalTravel(PlayerPortalEvent event)
-	{
-		if (config.isOneToOneNether() && event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL)
-		{
+	public void onPlayerPortalTravel(PlayerPortalEvent event) {
+		if (config.isOneToOneNether() && event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL) {
 			Location newLoc = event.getFrom();
 			newLoc.setWorld(event.getTo().getWorld());
 			event.setTo(newLoc);
 		}
 	}
 
-	@EventHandler(priority =  EventPriority.LOWEST)
-	public void onPortalCreate(PortalCreateEvent event)
-	{
-		if (!config.isReturnNetherPortal())
-		{
-			if (event.getReason() == PortalCreateEvent.CreateReason.FIRE && event.getWorld().getName().equals("world_nether"))
-			{
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPortalCreate(PortalCreateEvent event) {
+		if (!config.isReturnNetherPortal()) {
+			if (event.getReason() == PortalCreateEvent.CreateReason.FIRE && event.getWorld().getName().equals("world_nether")) {
 				event.setCancelled(true);
 			}
 		}
@@ -261,37 +252,29 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 
 	//Trying to stop dupe bugs via minecart inventories
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onEntityRightClick(PlayerInteractEntityEvent event)
-	{
-		if (!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories())
-		{
+	public void onEntityRightClick(PlayerInteractEntityEvent event) {
+		if (!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories()) {
 			Entity target = event.getRightClicked();
 
-			if (target.getType().equals(EntityType.MINECART_CHEST) && !config.isChestedMinecartInventories())
-			{
+			if (target.getType().equals(EntityType.MINECART_CHEST) && !config.isChestedMinecartInventories()) {
 				event.setCancelled(true);
 			}
 
-			if (target.getType().equals(EntityType.MINECART_HOPPER) && !config.isHopperMinecartInventories())
-			{
+			if (target.getType().equals(EntityType.MINECART_HOPPER) && !config.isHopperMinecartInventories()) {
 				event.setCancelled(true);
 			}
 		}
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
-	public void onInventoryMoveItemEvent(InventoryMoveItemEvent event)
-	{
-		if(!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories())
-		{
+	public void onInventoryMoveItemEvent(InventoryMoveItemEvent event) {
+		if (!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories()) {
 			InventoryHolder holder = event.getDestination().getHolder();
-			if(holder instanceof StorageMinecart && !config.isChestedMinecartInventories())
-			{
+			if (holder instanceof StorageMinecart && !config.isChestedMinecartInventories()) {
 				event.setCancelled(true);
 			}
 
-			if(holder instanceof HopperMinecart && !config.isHopperMinecartInventories())
-			{
+			if (holder instanceof HopperMinecart && !config.isHopperMinecartInventories()) {
 				event.setCancelled(true);
 			}
 

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -17,7 +17,13 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
-import org.bukkit.event.player.*;
+
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerBedEnterEvent;
+import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
 import org.bukkit.entity.Player;
 import org.bukkit.Material;
 import org.bukkit.Bukkit;
@@ -199,7 +205,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 	}
 
 	@SuppressWarnings("deprecation")
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void bedRClickToSetSpawn(PlayerInteractEvent event) {
 		if (!config.isEnabled() || !config.areDaytimeBedsEnabled() || event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock().getType() != Material.BED_BLOCK) {
 			return;

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -4,6 +4,10 @@ import java.util.logging.Level;
 import java.util.List;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.minecart.HopperMinecart;
+import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -12,7 +16,8 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
-import org.bukkit.event.player.PlayerBedEnterEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.entity.Player;
 import org.bukkit.Material;
 import org.bukkit.Bukkit;
@@ -27,10 +32,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameTuningConfig;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerPortalEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.PortalCreateEvent;
+import org.bukkit.inventory.InventoryHolder;
 
 /**
  * This is a grab-bag class to hold any _tuning_ related configurations that impact the 
@@ -108,7 +111,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			{
 				genStatus.append("disabled\n");
 			}
-			
+
 			// more?
 		} else {
 			genStatus.append("inactive");
@@ -249,4 +252,44 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			}
 		}
 	}
+
+	//Trying to stop dupe bugs via minecart inventories
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onEntityRightClick(PlayerInteractEntityEvent event)
+	{
+		if (!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories())
+		{
+			Entity target = event.getRightClicked();
+
+			if (target.getType().equals(EntityType.MINECART_CHEST) && !config.isChestedMinecartInventories())
+			{
+				event.setCancelled(true);
+			}
+
+			if (target.getType().equals(EntityType.MINECART_HOPPER) && !config.isHopperMinecartInventories())
+			{
+				event.setCancelled(true);
+			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onInventoryMoveItemEvent(InventoryMoveItemEvent event)
+	{
+		if(!config.isChestedMinecartInventories() || !config.isHopperMinecartInventories())
+		{
+			InventoryHolder holder = event.getDestination().getHolder();
+			if(holder instanceof StorageMinecart && !config.isChestedMinecartInventories())
+			{
+				event.setCancelled(true);
+			}
+
+			if(holder instanceof HopperMinecart && !config.isHopperMinecartInventories())
+			{
+				event.setCancelled(true);
+			}
+
+		}
+	}
+
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -108,11 +108,7 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			{
 				genStatus.append("disabled\n");
 			}
-
-
-
-
-
+			
 			// more?
 		} else {
 			genStatus.append("inactive");

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -3,6 +3,7 @@ package com.programmerdan.minecraft.simpleadminhacks.hacks;
 import java.util.logging.Level;
 import java.util.List;
 
+import org.bukkit.Location;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -10,6 +11,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.Material;
@@ -26,6 +28,9 @@ import com.programmerdan.minecraft.simpleadminhacks.SimpleAdminHacks;
 import com.programmerdan.minecraft.simpleadminhacks.SimpleHack;
 import com.programmerdan.minecraft.simpleadminhacks.configs.GameTuningConfig;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.world.PortalCreateEvent;
 
 /**
  * This is a grab-bag class to hold any _tuning_ related configurations that impact the 
@@ -94,6 +99,20 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 			} else {
 				genStatus.append("  Daytime Beds are disabled\n");
 			}
+
+			genStatus.append("  One To One Nether is ");
+			if (config.isOneToOneNether()) {
+				genStatus.append("enabled\n");
+			}
+			else
+			{
+				genStatus.append("disabled\n");
+			}
+
+
+
+
+
 			// more?
 		} else {
 			genStatus.append("inactive");
@@ -199,5 +218,39 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 
 		event.getPlayer().setBedSpawnLocation(event.getClickedBlock().getLocation());
 		event.getPlayer().sendTitle("", config.getDaytimeBedSpawnSetMessage());
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPortalTravel(EntityPortalEvent event)
+	{
+		if (config.isOneToOneNether())
+		{
+			Location newLoc = event.getFrom();
+			newLoc.setWorld(event.getTo().getWorld());
+			event.setTo(newLoc);
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onPlayerPortalTravel(PlayerPortalEvent event)
+	{
+		if (config.isOneToOneNether() && event.getCause() == PlayerTeleportEvent.TeleportCause.NETHER_PORTAL)
+		{
+			Location newLoc = event.getFrom();
+			newLoc.setWorld(event.getTo().getWorld());
+			event.setTo(newLoc);
+		}
+	}
+
+	@EventHandler(priority =  EventPriority.LOWEST)
+	public void onPortalCreate(PortalCreateEvent event)
+	{
+		if (!config.isReturnNetherPortal())
+		{
+			if (event.getReason() == PortalCreateEvent.CreateReason.FIRE && event.getWorld().getName().equals("world_nether"))
+			{
+				event.setCancelled(true);
+			}
+		}
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/hacks/GameTuning.java
@@ -44,13 +44,13 @@ import org.bukkit.inventory.InventoryHolder;
 /**
  * This is a grab-bag class to hold any _tuning_ related configurations that impact the
  * game, server-wide.
- * <p/>
+ *
  * It's part of a series of focused hacks.
- * <p/>
+ *
  * {@link GameFixes} is focused on things that are broken or don't work, and attempts to fix them.
  * {@link GameFeatures} focuses on enabling and disabling features, like elytra, various potion states.
  * {@link GameTuning} neither fixes nor disables, but rather adjusts and reconfigures.
- * <p/>
+ *
  * Currently you can control the following:
  * - BlockEntity limits per chunk
  * - Setting bed during the day instead of just at night
@@ -126,12 +126,12 @@ public class GameTuning extends SimpleHack<GameTuningConfig> implements Listener
 	public static GameTuningConfig generate(SimpleAdminHacks plugin, ConfigurationSection config) {
 		return new GameTuningConfig(plugin, config);
 	}
-	
+
 	/* From here on, the actual meat of the hack. Above is basically boilerplate for micro-plugins.*/
 
 	/**
 	 * Many thanks to BlackXNT for his work on this event in Humbug, which I have largely copied and expanded.
-	 * <p/>
+	 *
 	 * This tracks block placements, and if a limit is configured and the block is a TileEntity w/ state,
 	 * will reject the placement if otherwise it would exceed limits for the Chunk.
 	 *

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -55,8 +55,12 @@ hacks:
       spawnSetMessage: '&7Your spawn has been set.'
     # Makes nether ratio 1 to 1
     oneToOneNether: false
-    #Return nether portal, true = enabled    false = disabled
+    # Return nether portal, true = enabled    false = disabled
     returnNetherPortal: true
+    # Disables minecart inventories (trying to fix dupe issues)
+    # enabled = able to right click   disabled = not able to right click
+    chestedMinecartInventories: true
+    hopperMinecartInventories: true
   CTAnnounce:
     enabled: false
     delay: 10000

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,7 +27,7 @@ hacks:
     # WeepingAngel bans people when they die, the numbers are in minutes.
     weepingAngel:
       enabled: false
-      enviorment: 1
+      environment: 1
       playerKill: 5
   GameFixes:
     enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,10 @@ hacks:
     enderChestPlacement: false
     elytra: off
     chorus_fruit: off
+    weepingAngel:
+      enabled: false
+      enviorment: 1
+      playerKill: 5
   GameFixes:
     enabled: true
     blockElytraBreakBug: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,7 @@ hacks:
     canStorageTeleport: false
     stopHopperDupe: true
     stopRailDupe: true
+    stopEndPortalDeltion: true
   GameTuning:
     enabled: true
     chunkLimits:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,7 @@ hacks:
     damageOnElytraBreakBug: 1.0
     canStorageTeleport: false
     stopHopperDupe: true
+    stopRailDupe: true
   GameTuning:
     enabled: true
     chunkLimits:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -48,6 +48,10 @@ hacks:
     daytimeBed:
       enabled: true
       spawnSetMessage: '&7Your spawn has been set.'
+    # Makes nether ratio 1 to 1
+    oneToOneNether: false
+    #Return nether portal, true = enabled    false = disabled
+    returnNetherPortal: true
   CTAnnounce:
     enabled: false
     delay: 10000

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,7 +36,7 @@ hacks:
     canStorageTeleport: false
     stopHopperDupe: true
     stopRailDupe: true
-    stopEndPortalDeltion: true
+    stopEndPortalDeletion: true
   GameTuning:
     enabled: true
     chunkLimits:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,7 @@ hacks:
     enderChestPlacement: false
     elytra: off
     chorus_fruit: off
+    # WeepingAngel bans people when they die, the numbers are in minutes.
     weepingAngel:
       enabled: false
       enviorment: 1


### PR DESCRIPTION
Dupe fix prevents anything that inherits InventoryHolder and prevents it from going through a portal. It also ignores players thanks to the event not throwing if a player triggers.

Should probably be squashed

This grew while talking about it in discord and is no longer just a simple dupe fix but alas it should fix things... probably... maybe... hopefully.