### PR TITLE
Fix signs in Minecart TPs

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/simpleadminhacks/util/TeleportUtil.java
+++ b/src/main/java/com/programmerdan/minecraft/simpleadminhacks/util/TeleportUtil.java
@@ -20,7 +20,7 @@ public class TeleportUtil {
 			return false;
 		}
 		final Block above = block.getRelative(BlockFace.UP);
-		if (above.getType().isSolid()) {
+		if (above.getType().isSolid() || above.getType() == Material.SIGN) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
When you leave a rail that has a sign above it, it should no longer teleport you.